### PR TITLE
StreamProcess: streaming endpoint for large payloads

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,374 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,data_processing/pbs
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=grpc._cython.cygrpc
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+
+disable=
+    attribute-defined-outside-init,
+    duplicate-code,
+    fixme,
+    invalid-name,
+    missing-docstring,
+    protected-access,
+    too-few-public-methods,
+    wildcard-import,
+    mixed-indentation,
+    redefined-variable-type
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=2000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# List of decorators that define properties, such as abc.abstractproperty.
+property-classes=abc.abstractproperty
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=tensorflow
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject, optparse.Values, thread._local, _thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+# List of decorators that create context managers from functions, such as
+# contextlib.contextmanager.
+contextmanager-decorators=contextlib.contextmanager
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=10
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=25
+
+# Maximum number of return / yield for function / method body
+max-returns=11
+
+# Maximum number of branch for function / method body
+max-branches=26
+
+# Maximum number of statements in function / method body
+max-statements=100
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=11
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=25
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/data_processing/pbs/process_pb2.py
+++ b/data_processing/pbs/process_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='tensorflow.serving',
   syntax='proto3',
   serialized_options=_b('\370\001\001'),
-  serialized_pb=_b('\n\rprocess.proto\x12\x12tensorflow.serving\x1a\x0ctensor.proto\x1a\x0e\x66unction.proto\"\xe8\x01\n\x0eProcessRequest\x12\x37\n\rfunction_spec\x18\x01 \x01(\x0b\x32 .tensorflow.serving.FunctionSpec\x12>\n\x06inputs\x18\x02 \x03(\x0b\x32..tensorflow.serving.ProcessRequest.InputsEntry\x12\x15\n\routput_filter\x18\x03 \x03(\t\x1a\x46\n\x0bInputsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x05value\x18\x02 \x01(\x0b\x32\x17.tensorflow.TensorProto:\x02\x38\x01\"\x9d\x01\n\x0fProcessResponse\x12\x41\n\x07outputs\x18\x01 \x03(\x0b\x32\x30.tensorflow.serving.ProcessResponse.OutputsEntry\x1aG\n\x0cOutputsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x05value\x18\x02 \x01(\x0b\x32\x17.tensorflow.TensorProto:\x02\x38\x01\x42\x03\xf8\x01\x01\x62\x06proto3')
+  serialized_pb=_b('\n\rprocess.proto\x12\x12tensorflow.serving\x1a\x0ctensor.proto\x1a\x0e\x66unction.proto\"\xe8\x01\n\x0eProcessRequest\x12\x37\n\rfunction_spec\x18\x01 \x01(\x0b\x32 .tensorflow.serving.FunctionSpec\x12>\n\x06inputs\x18\x02 \x03(\x0b\x32..tensorflow.serving.ProcessRequest.InputsEntry\x12\x15\n\routput_filter\x18\x03 \x03(\t\x1a\x46\n\x0bInputsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x05value\x18\x02 \x01(\x0b\x32\x17.tensorflow.TensorProto:\x02\x38\x01\"\x9d\x01\n\x0fProcessResponse\x12\x41\n\x07outputs\x18\x01 \x03(\x0b\x32\x30.tensorflow.serving.ProcessResponse.OutputsEntry\x1aG\n\x0cOutputsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x05value\x18\x02 \x01(\x0b\x32\x17.tensorflow.TensorProto:\x02\x38\x01\"\xfb\x01\n\x15\x43hunkedProcessRequest\x12\x37\n\rfunction_spec\x18\x01 \x01(\x0b\x32 .tensorflow.serving.FunctionSpec\x12\x45\n\x06inputs\x18\x02 \x03(\x0b\x32\x35.tensorflow.serving.ChunkedProcessRequest.InputsEntry\x12\x15\n\routput_filter\x18\x03 \x03(\t\x12\r\n\x05shape\x18\x04 \x03(\x03\x12\r\n\x05\x64type\x18\x05 \x01(\t\x1a-\n\x0bInputsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x0c:\x02\x38\x01\"\xb0\x01\n\x16\x43hunkedProcessResponse\x12H\n\x07outputs\x18\x01 \x03(\x0b\x32\x37.tensorflow.serving.ChunkedProcessResponse.OutputsEntry\x12\r\n\x05shape\x18\x04 \x03(\x03\x12\r\n\x05\x64type\x18\x05 \x01(\t\x1a.\n\x0cOutputsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x0c:\x02\x38\x01\x42\x03\xf8\x01\x01\x62\x06proto3')
   ,
   dependencies=[tensor__pb2.DESCRIPTOR,function__pb2.DESCRIPTOR,])
 
@@ -177,6 +177,184 @@ _PROCESSRESPONSE = _descriptor.Descriptor(
   serialized_end=460,
 )
 
+
+_CHUNKEDPROCESSREQUEST_INPUTSENTRY = _descriptor.Descriptor(
+  name='InputsEntry',
+  full_name='tensorflow.serving.ChunkedProcessRequest.InputsEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='tensorflow.serving.ChunkedProcessRequest.InputsEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='tensorflow.serving.ChunkedProcessRequest.InputsEntry.value', index=1,
+      number=2, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=_b('8\001'),
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=669,
+  serialized_end=714,
+)
+
+_CHUNKEDPROCESSREQUEST = _descriptor.Descriptor(
+  name='ChunkedProcessRequest',
+  full_name='tensorflow.serving.ChunkedProcessRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='function_spec', full_name='tensorflow.serving.ChunkedProcessRequest.function_spec', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='inputs', full_name='tensorflow.serving.ChunkedProcessRequest.inputs', index=1,
+      number=2, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='output_filter', full_name='tensorflow.serving.ChunkedProcessRequest.output_filter', index=2,
+      number=3, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='shape', full_name='tensorflow.serving.ChunkedProcessRequest.shape', index=3,
+      number=4, type=3, cpp_type=2, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='dtype', full_name='tensorflow.serving.ChunkedProcessRequest.dtype', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_CHUNKEDPROCESSREQUEST_INPUTSENTRY, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=463,
+  serialized_end=714,
+)
+
+
+_CHUNKEDPROCESSRESPONSE_OUTPUTSENTRY = _descriptor.Descriptor(
+  name='OutputsEntry',
+  full_name='tensorflow.serving.ChunkedProcessResponse.OutputsEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='tensorflow.serving.ChunkedProcessResponse.OutputsEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='tensorflow.serving.ChunkedProcessResponse.OutputsEntry.value', index=1,
+      number=2, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=_b('8\001'),
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=847,
+  serialized_end=893,
+)
+
+_CHUNKEDPROCESSRESPONSE = _descriptor.Descriptor(
+  name='ChunkedProcessResponse',
+  full_name='tensorflow.serving.ChunkedProcessResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='outputs', full_name='tensorflow.serving.ChunkedProcessResponse.outputs', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='shape', full_name='tensorflow.serving.ChunkedProcessResponse.shape', index=1,
+      number=4, type=3, cpp_type=2, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='dtype', full_name='tensorflow.serving.ChunkedProcessResponse.dtype', index=2,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_CHUNKEDPROCESSRESPONSE_OUTPUTSENTRY, ],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=717,
+  serialized_end=893,
+)
+
 _PROCESSREQUEST_INPUTSENTRY.fields_by_name['value'].message_type = tensor__pb2._TENSORPROTO
 _PROCESSREQUEST_INPUTSENTRY.containing_type = _PROCESSREQUEST
 _PROCESSREQUEST.fields_by_name['function_spec'].message_type = function__pb2._FUNCTIONSPEC
@@ -184,8 +362,15 @@ _PROCESSREQUEST.fields_by_name['inputs'].message_type = _PROCESSREQUEST_INPUTSEN
 _PROCESSRESPONSE_OUTPUTSENTRY.fields_by_name['value'].message_type = tensor__pb2._TENSORPROTO
 _PROCESSRESPONSE_OUTPUTSENTRY.containing_type = _PROCESSRESPONSE
 _PROCESSRESPONSE.fields_by_name['outputs'].message_type = _PROCESSRESPONSE_OUTPUTSENTRY
+_CHUNKEDPROCESSREQUEST_INPUTSENTRY.containing_type = _CHUNKEDPROCESSREQUEST
+_CHUNKEDPROCESSREQUEST.fields_by_name['function_spec'].message_type = function__pb2._FUNCTIONSPEC
+_CHUNKEDPROCESSREQUEST.fields_by_name['inputs'].message_type = _CHUNKEDPROCESSREQUEST_INPUTSENTRY
+_CHUNKEDPROCESSRESPONSE_OUTPUTSENTRY.containing_type = _CHUNKEDPROCESSRESPONSE
+_CHUNKEDPROCESSRESPONSE.fields_by_name['outputs'].message_type = _CHUNKEDPROCESSRESPONSE_OUTPUTSENTRY
 DESCRIPTOR.message_types_by_name['ProcessRequest'] = _PROCESSREQUEST
 DESCRIPTOR.message_types_by_name['ProcessResponse'] = _PROCESSRESPONSE
+DESCRIPTOR.message_types_by_name['ChunkedProcessRequest'] = _CHUNKEDPROCESSREQUEST
+DESCRIPTOR.message_types_by_name['ChunkedProcessResponse'] = _CHUNKEDPROCESSRESPONSE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
 ProcessRequest = _reflection.GeneratedProtocolMessageType('ProcessRequest', (_message.Message,), dict(
@@ -218,8 +403,40 @@ ProcessResponse = _reflection.GeneratedProtocolMessageType('ProcessResponse', (_
 _sym_db.RegisterMessage(ProcessResponse)
 _sym_db.RegisterMessage(ProcessResponse.OutputsEntry)
 
+ChunkedProcessRequest = _reflection.GeneratedProtocolMessageType('ChunkedProcessRequest', (_message.Message,), dict(
+
+  InputsEntry = _reflection.GeneratedProtocolMessageType('InputsEntry', (_message.Message,), dict(
+    DESCRIPTOR = _CHUNKEDPROCESSREQUEST_INPUTSENTRY,
+    __module__ = 'process_pb2'
+    # @@protoc_insertion_point(class_scope:tensorflow.serving.ChunkedProcessRequest.InputsEntry)
+    ))
+  ,
+  DESCRIPTOR = _CHUNKEDPROCESSREQUEST,
+  __module__ = 'process_pb2'
+  # @@protoc_insertion_point(class_scope:tensorflow.serving.ChunkedProcessRequest)
+  ))
+_sym_db.RegisterMessage(ChunkedProcessRequest)
+_sym_db.RegisterMessage(ChunkedProcessRequest.InputsEntry)
+
+ChunkedProcessResponse = _reflection.GeneratedProtocolMessageType('ChunkedProcessResponse', (_message.Message,), dict(
+
+  OutputsEntry = _reflection.GeneratedProtocolMessageType('OutputsEntry', (_message.Message,), dict(
+    DESCRIPTOR = _CHUNKEDPROCESSRESPONSE_OUTPUTSENTRY,
+    __module__ = 'process_pb2'
+    # @@protoc_insertion_point(class_scope:tensorflow.serving.ChunkedProcessResponse.OutputsEntry)
+    ))
+  ,
+  DESCRIPTOR = _CHUNKEDPROCESSRESPONSE,
+  __module__ = 'process_pb2'
+  # @@protoc_insertion_point(class_scope:tensorflow.serving.ChunkedProcessResponse)
+  ))
+_sym_db.RegisterMessage(ChunkedProcessResponse)
+_sym_db.RegisterMessage(ChunkedProcessResponse.OutputsEntry)
+
 
 DESCRIPTOR._options = None
 _PROCESSREQUEST_INPUTSENTRY._options = None
 _PROCESSRESPONSE_OUTPUTSENTRY._options = None
+_CHUNKEDPROCESSREQUEST_INPUTSENTRY._options = None
+_CHUNKEDPROCESSRESPONSE_OUTPUTSENTRY._options = None
 # @@protoc_insertion_point(module_scope)

--- a/data_processing/pbs/processing_service_pb2.py
+++ b/data_processing/pbs/processing_service_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='tensorflow.serving',
   syntax='proto3',
   serialized_options=_b('\370\001\001'),
-  serialized_pb=_b('\n\x18processing_service.proto\x12\x12tensorflow.serving\x1a\rprocess.proto2g\n\x11ProcessingService\x12R\n\x07Process\x12\".tensorflow.serving.ProcessRequest\x1a#.tensorflow.serving.ProcessResponseB\x03\xf8\x01\x01\x62\x06proto3')
+  serialized_pb=_b('\n\x18processing_service.proto\x12\x12tensorflow.serving\x1a\rprocess.proto2\xd3\x01\n\x11ProcessingService\x12R\n\x07Process\x12\".tensorflow.serving.ProcessRequest\x1a#.tensorflow.serving.ProcessResponse\x12j\n\rStreamProcess\x12).tensorflow.serving.ChunkedProcessRequest\x1a*.tensorflow.serving.ChunkedProcessResponse(\x01\x30\x01\x42\x03\xf8\x01\x01\x62\x06proto3')
   ,
   dependencies=[process__pb2.DESCRIPTOR,])
 
@@ -37,8 +37,8 @@ _PROCESSINGSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=63,
-  serialized_end=166,
+  serialized_start=64,
+  serialized_end=275,
   methods=[
   _descriptor.MethodDescriptor(
     name='Process',
@@ -47,6 +47,15 @@ _PROCESSINGSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=process__pb2._PROCESSREQUEST,
     output_type=process__pb2._PROCESSRESPONSE,
+    serialized_options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='StreamProcess',
+    full_name='tensorflow.serving.ProcessingService.StreamProcess',
+    index=1,
+    containing_service=None,
+    input_type=process__pb2._CHUNKEDPROCESSREQUEST,
+    output_type=process__pb2._CHUNKEDPROCESSRESPONSE,
     serialized_options=None,
   ),
 ])

--- a/data_processing/pbs/processing_service_pb2_grpc.py
+++ b/data_processing/pbs/processing_service_pb2_grpc.py
@@ -19,6 +19,11 @@ class ProcessingServiceStub(object):
         request_serializer=process__pb2.ProcessRequest.SerializeToString,
         response_deserializer=process__pb2.ProcessResponse.FromString,
         )
+    self.StreamProcess = channel.stream_stream(
+        '/tensorflow.serving.ProcessingService/StreamProcess',
+        request_serializer=process__pb2.ChunkedProcessRequest.SerializeToString,
+        response_deserializer=process__pb2.ChunkedProcessResponse.FromString,
+        )
 
 
 class ProcessingServiceServicer(object):
@@ -32,6 +37,13 @@ class ProcessingServiceServicer(object):
     context.set_details('Method not implemented!')
     raise NotImplementedError('Method not implemented!')
 
+  def StreamProcess(self, request_iterator, context):
+    # missing associated documentation comment in .proto file
+    pass
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
 
 def add_ProcessingServiceServicer_to_server(servicer, server):
   rpc_method_handlers = {
@@ -39,6 +51,11 @@ def add_ProcessingServiceServicer_to_server(servicer, server):
           servicer.Process,
           request_deserializer=process__pb2.ProcessRequest.FromString,
           response_serializer=process__pb2.ProcessResponse.SerializeToString,
+      ),
+      'StreamProcess': grpc.stream_stream_rpc_method_handler(
+          servicer.StreamProcess,
+          request_deserializer=process__pb2.ChunkedProcessRequest.FromString,
+          response_serializer=process__pb2.ChunkedProcessResponse.SerializeToString,
       ),
   }
   generic_handler = grpc.method_handlers_generic_handler(

--- a/data_processing/processing.py
+++ b/data_processing/processing.py
@@ -29,6 +29,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
+from scipy import ndimage
 from skimage import morphology
 from skimage.feature import peak_local_max
 from skimage.measure import label
@@ -138,7 +139,8 @@ def watershed(image, min_distance=10, threshold_abs=0.05):
         labels=labels,
         exclude_border=False)
 
-    markers = label(local_maxi)
+    # markers = label(local_maxi)
+    markers = ndimage.label(local_maxi)[0]
     segments = morphology.watershed(-distance, markers, mask=labels)
     results = np.expand_dims(segments, axis=-1)
     results = morphology.remove_small_objects(
@@ -159,7 +161,7 @@ def deepcell(prediction, threshold=.8):
         prediction = np.squeeze(prediction, axis=0)
     interior = prediction[..., 2] > threshold
     data = np.expand_dims(interior, axis=-1)
-    labeled = label(data)
+    labeled = ndimage.label(data)[0]
     labeled = morphology.remove_small_objects(
         labeled, min_size=50, connectivity=1)
     return labeled

--- a/protos/process.proto
+++ b/protos/process.proto
@@ -36,3 +36,43 @@ message ProcessResponse {
   // Output tensors.
   map<string, TensorProto> outputs = 1;
 }
+
+message ChunkedProcessRequest {
+  // Model Specification.
+  FunctionSpec function_spec = 1;
+
+  // Input tensors.
+  // Names of input tensor are alias names. The mapping from aliases to real
+  // input tensor names is expected to be stored as named generic signature
+  // under the key "inputs" in the model export.
+  // Each alias listed in a generic signature named "inputs" should be provided
+  // exactly once in order to run the processing.
+  map<string, bytes> inputs = 2;
+
+  // Output filter.
+  // Names specified are alias names. The mapping from aliases to real output
+  // tensor names is expected to be stored as named generic signature under
+  // the key "outputs" in the model export.
+  // Only tensors specified here will be run/fetched and returned, with the
+  // exception that when none is specified, all tensors specified in the
+  // named signature will be run/fetched and returned.
+  repeated string output_filter = 3;
+
+  // Shape of chunked array.
+  repeated int64 shape = 4;
+
+  // Dtype of chunked array.
+  string dtype = 5;
+}
+
+// Response for ChunkedProcessRequest on successful run.
+message ChunkedProcessResponse {
+  // Output tensors.
+  map<string, bytes> outputs = 1;
+
+  // Shape of chunked array.
+  repeated int64 shape = 4;
+
+  // Dtype of chunked array.
+  string dtype = 5;
+}

--- a/protos/processing_service.proto
+++ b/protos/processing_service.proto
@@ -9,4 +9,5 @@ import "process.proto";
 service ProcessingService {
   // Process -- provides access to a data processing function
   rpc Process(ProcessRequest) returns (ProcessResponse);
+  rpc StreamProcess(stream ChunkedProcessRequest) returns (stream ChunkedProcessResponse);
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 grpcio>=1.17.1,<2.0.0
-numpy>=1.15.0,<2.0.0
+numpy>=1.15.0,<1.16.0
+scipy>=1.2.0<2.0.0
 scikit-image>=0.14.0,<1.0.0
 python-decouple>=3.1,<4.0
 protobuf==3.6.1

--- a/server.py
+++ b/server.py
@@ -28,18 +28,18 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+from concurrent import futures
+
 import os
 import sys
 import time
 import logging
 
+import numpy as np
 import grpc
 from grpc._cython import cygrpc
-from concurrent import futures
-from dict_to_protobuf import dict_to_protobuf
 
 from data_processing.pbs import process_pb2
-from data_processing.pbs import processing_service_pb2
 from data_processing.pbs import processing_service_pb2_grpc
 from data_processing.utils import get_function
 from data_processing.utils import protobuf_request_to_dict
@@ -47,6 +47,7 @@ from data_processing.utils import make_tensor_proto
 
 
 def initialize_logger(debug_mode=False):
+    """Sets up the logger"""
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
 
@@ -67,7 +68,7 @@ class ProcessingServicer(processing_service_pb2_grpc.ProcessingServiceServicer):
 
     def Process(self, request, context):
         """Expose Process() and all the `data_processing` functions"""
-        _logger = logging.getLogger()
+        _logger = logging.getLogger('ProcessingServicer.Process')
         F = get_function(request.function_spec.type,
                          request.function_spec.name)
 

--- a/server.py
+++ b/server.py
@@ -75,12 +75,12 @@ class ProcessingServicer(processing_service_pb2_grpc.ProcessingServiceServicer):
         t = time.time()
         data = protobuf_request_to_dict(request)
         image = data['image']
-        _logger.info('Loaded data into numpy array with shape %s in %s s',
+        _logger.info('Loaded data into numpy array with shape %s in %ss',
                      image.shape, time.time() - t)
 
         t = time.time()
         processed_image = F(image)
-        _logger.info('%s processed data into shape %s in %s s',
+        _logger.info('%s processed data into shape %s in %ss',
                      str(F.__name__).capitalize(), processed_image.shape,
                      time.time() - t)
 
@@ -88,7 +88,7 @@ class ProcessingServicer(processing_service_pb2_grpc.ProcessingServiceServicer):
         response = process_pb2.ProcessResponse()
         tensor_proto = make_tensor_proto(processed_image, 'DT_INT32')
         response.outputs['results'].CopyFrom(tensor_proto)  # pylint: disable=E1101
-        _logger.info('Prepared response object in %s s', time.time() - t)
+        _logger.info('Prepared response object in %ss', time.time() - t)
         return response
 
     def StreamProcess(self, request_iterator, context):
@@ -116,14 +116,14 @@ class ProcessingServicer(processing_service_pb2_grpc.ProcessingServiceServicer):
 
         t = time.time()
         image = np.frombuffer(npbytes, dtype=dtype).reshape(shape)
-        _logger.info('Loaded data into numpy array with shape %s in %s s',
+        _logger.info('Loaded data into numpy array with shape %s in %ss',
                      image.shape, time.time() - t)
 
         t = time.time()
         processed_image = F(image)
 
         processed_shape = processed_image.shape  # to reshape client-side
-        _logger.info('%s processed %s data into shape %s in %s s',
+        _logger.info('%s processed %s data into shape %s in %ss',
                      str(F.__name__).capitalize(), processed_image.dtype,
                      processed_shape, time.time() - t)
 
@@ -144,7 +144,7 @@ class ProcessingServicer(processing_service_pb2_grpc.ProcessingServiceServicer):
             _logger.debug('Creating response object took: %s', time.time() - t)
             yield response
 
-        _logger.info('Finished all responses in: %s s', time.time() - _t)
+        _logger.info('Finished all responses in: %ss', time.time() - _t)
 
 
 if __name__ == '__main__':

--- a/server.py
+++ b/server.py
@@ -149,30 +149,30 @@ class ProcessingServicer(processing_service_pb2_grpc.ProcessingServiceServicer):
 
 if __name__ == '__main__':
     initialize_logger()
-    _logger = logging.getLogger()
+    LOGGER = logging.getLogger()
     LISTEN_PORT = os.getenv('LISTEN_PORT', 8080)
 
     # define custom server options
-    options=[(cygrpc.ChannelArgKey.max_send_message_length, -1),
-             (cygrpc.ChannelArgKey.max_receive_message_length, -1)]
+    OPTIONS = [(cygrpc.ChannelArgKey.max_send_message_length, -1),
+               (cygrpc.ChannelArgKey.max_receive_message_length, -1)]
 
     # create a gRPC server with custom options
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10),
-                         options=options)
+    SERVER = grpc.server(futures.ThreadPoolExecutor(max_workers=10),
+                         options=OPTIONS)
 
     # use the generated function `add_ProcessingServicer_to_server`
     # to add the defined class to the server
     processing_service_pb2_grpc.add_ProcessingServiceServicer_to_server(
-        ProcessingServicer(), server)
+        ProcessingServicer(), SERVER)
 
-    _logger.info('Starting server. Listening on port %s', LISTEN_PORT)
-    server.add_insecure_port('[::]:{}'.format(LISTEN_PORT))
-    server.start()
+    LOGGER.info('Starting server. Listening on port %s', LISTEN_PORT)
+    SERVER.add_insecure_port('[::]:{}'.format(LISTEN_PORT))
+    SERVER.start()
 
-    # since server.start() will not block,
+    # since SERVER.start() will not block,
     # a sleep-loop is added to keep alive
     try:
         while True:
             time.sleep(86400)  # 24 hours
     except KeyboardInterrupt:
-        server.stop(0)
+        SERVER.stop(0)


### PR DESCRIPTION
Some images that are too large to send in one payload can be turned into bytes and sent via many 4MB streamed payloads.  The results are turned back into an array with `np.frombuffer(bytes, dtype=dtype).reshape(shape)`.  Note that both `shape` and `dtype` from the original array must be passed in the requests, and the resulting `shape` and `dtype` must be passed in the responses.